### PR TITLE
Faster assignment with new logic

### DIFF
--- a/stochatreat/stochatreat.py
+++ b/stochatreat/stochatreat.py
@@ -179,7 +179,7 @@ def stochatreat(data: pd.DataFrame,
     # re-arrange blocks
     # =========================================================================
 
-    if misfit_strategy == "global":
+    if misfit_strategy == 'global':
         # separate the global misfits
         misfit_data = data.groupby('block').apply(
             lambda x: x.sample(
@@ -187,7 +187,7 @@ def stochatreat(data: pd.DataFrame,
                 replace=False,
                 random_state=random_state
             )
-        ).droplevel(level="block")
+        ).droplevel(level='block')
         good_form_data = data.drop(index=misfit_data.index)
 
         # assign the misfits their own block and concatenate
@@ -208,7 +208,7 @@ def stochatreat(data: pd.DataFrame,
     data.loc[:, 'block'] = data['block'].astype(str)
 
     # add fake rows for each group so the total number can be divided by num_treatments
-    fake = pd.DataFrame({"fake": data.groupby('block').size()}).reset_index()  
+    fake = pd.DataFrame({'fake': data.groupby('block').size()}).reset_index()  
     fake.loc[:, 'fake'] = (
         (lcm_prob_denominators - fake['fake'] % lcm_prob_denominators) % lcm_prob_denominators
     )
@@ -227,14 +227,14 @@ def stochatreat(data: pd.DataFrame,
     )
     # lookup treatment name for permutations. This works because we flatten
     # row-major style, i.e. one row after another.
-    ordered["treat"] = treat_mask[permutations].flatten(order='C')
-    ordered = ordered[~ordered["fake"]].drop("fake", 1)
+    ordered['treat'] = treat_mask[permutations].flatten(order='C')
+    ordered = ordered[~ordered['fake']].drop('fake', 1)
 
-    data.loc[:, 'treat'] = ordered["treat"]
+    data.loc[:, 'treat'] = ordered['treat']
 
     # add unique integer ids for the blocks
-    data["block_id"] = data.groupby(["block"]).ngroup()
-    data = data.drop(columns=["block"])
+    data['block_id'] = data.groupby(['block']).ngroup()
+    data = data.drop(columns=['block'])
 
     data['treat'] = data['treat'].astype(np.int64)
 

--- a/stochatreat/stochatreat.py
+++ b/stochatreat/stochatreat.py
@@ -228,7 +228,7 @@ def stochatreat(data: pd.DataFrame,
     # lookup treatment name for permutations. This works because we flatten
     # row-major style, i.e. one row after another.
     ordered['treat'] = treat_mask[permutations].flatten(order='C')
-    ordered = ordered[~ordered['fake']].drop('fake', 1)
+    ordered = ordered[~ordered['fake']].drop(columns=['fake'])
 
     data.loc[:, 'treat'] = ordered['treat']
 

--- a/stochatreat/stochatreat.py
+++ b/stochatreat/stochatreat.py
@@ -210,7 +210,7 @@ def stochatreat(data: pd.DataFrame,
     # add fake rows for each group so the total number can be divided by num_treatments
     fake = pd.DataFrame({"fake": data.groupby('block').size()}).reset_index()  
     fake.loc[:, 'fake'] = (
-        (len(treat_mask) - fake['fake'] % len(treat_mask)) % len(treat_mask)
+        (lcm_prob_denominators - fake['fake'] % lcm_prob_denominators) % lcm_prob_denominators
     )
     fake_rep = pd.DataFrame(fake.values.repeat(fake['fake'], axis=0), columns=fake.columns)
 
@@ -222,7 +222,7 @@ def stochatreat(data: pd.DataFrame,
     # generate random permutations without loop by generating large number of
     # random values and sorting row (meaning one permutation) wise
     permutations = np.argsort(
-        np.random.rand(len(ordered) // len(treat_mask), len(treat_mask)),
+        np.random.rand(len(ordered) // lcm_prob_denominators, lcm_prob_denominators),
         axis=1
     )
     # lookup treatment name for permutations. This works because we flatten

--- a/stochatreat/stochatreat.py
+++ b/stochatreat/stochatreat.py
@@ -84,6 +84,7 @@ def stochatreat(data: pd.DataFrame,
                                  random_state=42)
         >>> data = data.merge(treats, how='left', on='myid')
     """
+    R = np.random.RandomState(random_state)
 
     # =========================================================================
     # do checks
@@ -234,7 +235,7 @@ def stochatreat(data: pd.DataFrame,
     # generate random permutations without loop by generating large number of
     # random values and sorting row (meaning one permutation) wise
     permutations = np.argsort(
-        np.random.rand(len(ordered) // lcm_prob_denominators, lcm_prob_denominators),
+        R.rand(len(ordered) // lcm_prob_denominators, lcm_prob_denominators),
         axis=1
     )
     # lookup treatment name for permutations. This works because we flatten


### PR DESCRIPTION
New assignment logic for the `stratum` strategy for performance (~4x times faster runtime on the tests)

Key idea:
- add rows to each stratum so that each stratum's length is a multiple of `lcm_prob_denominators`
so now the length of the whole data is a multiple of `lcm_prob_denominators`
- sort the data by stratum
- randomly permutate the `treat_mask` (total_length_of_augmented_data // `lcm_prob_denominators`) times and assign the permutations to the sorted augmented data
- filter out the fake rows
