### PR TITLE
Avoid slicing and dicing in sampling

### DIFF
--- a/stochatreat/stochatreat.py
+++ b/stochatreat/stochatreat.py
@@ -156,7 +156,6 @@ def stochatreat(data: pd.DataFrame,
         data = data.groupby('stratum_id').apply(
             lambda x: x.sample(
                 n=reduced_sizes[x.name],
-                replace=False,
                 random_state=random_state
             )
         ).droplevel(level='stratum_id')

--- a/stochatreat/stochatreat.py
+++ b/stochatreat/stochatreat.py
@@ -139,7 +139,6 @@ def stochatreat(data: pd.DataFrame,
 
     # combine block cells - by assigning stratum ids
     data['stratum_id'] = data.groupby(stratum_cols).ngroup()
-    strata = data['stratum_id'].unique()
 
     # keep only ids and concatenated strata
     data = data[[idx_col] + ['stratum_id']].copy()
@@ -152,20 +151,15 @@ def stochatreat(data: pd.DataFrame,
             .value_counts(normalize=True)
             .sort_index()
         )
-        reduced_sizes = (strata_fracs * size).round().astype(int).tolist()
+        reduced_sizes = (strata_fracs * size).round().astype(int)
         # draw sample
-        sample = []
-        for i, stratum in enumerate(strata):
-            stratum_sample = data[data['stratum_id'] == stratum].copy()
-            # draw sample using fractions
-            stratum_sample = stratum_sample.sample(
-                n=reduced_sizes[i],
+        data = data.groupby('stratum_id').apply(
+            lambda x: x.sample(
+                n=reduced_sizes[x.name],
                 replace=False,
                 random_state=random_state
             )
-            sample.append(stratum_sample)
-        # concatenate samples from each stratum
-        data = pd.concat(sample)
+        ).droplevel(level='stratum_id')
 
         assert sum(reduced_sizes) == len(data)
 

--- a/tests/test_stochatreat_input_output.py
+++ b/tests/test_stochatreat_input_output.py
@@ -329,3 +329,19 @@ def test_stochatreat_output_index_and_idx_col_correspondence(
     pd.testing.assert_series_equal(
         data_with_rand_index[idx_col], treatments[idx_col]
     )
+
+def test_stochatreat_output_sample(correct_params):
+    """
+    Tests that the function samples to the correct size
+    """
+    size = 100
+    assignments = stochatreat(
+        data=correct_params["data"],
+        stratum_cols=["stratum"],
+        treats=correct_params["treat"],
+        idx_col=correct_params["idx_col"],
+        probs=correct_params["probs"],
+        size=size
+    )
+
+    assert len(assignments) == size


### PR DESCRIPTION
Replace the slicing and concatenating with .apply() in sampling procedure