### PR TITLE
Succinct assignment

### DIFF
--- a/stochatreat/stochatreat.py
+++ b/stochatreat/stochatreat.py
@@ -119,6 +119,9 @@ def stochatreat(data: pd.DataFrame,
         idx_col = 'index'
     elif type(idx_col) is not str:
         raise TypeError('idx_col has to be a string.')
+    
+    # retrieve type to check and re-assign in the end
+    idx_col_type = data[idx_col].dtype
 
     # check for unique identifiers
     if data[idx_col].duplicated(keep=False).sum() > 0:
@@ -226,22 +229,24 @@ def stochatreat(data: pd.DataFrame,
     data.loc[:, 'fake'] = False
     fake_rep.loc[:, 'fake'] = True
 
-    ordered = (pd.concat([data, fake_rep], sort=False)
+    data = (pd.concat([data, fake_rep], sort=False)
         .sort_values(['stratum_id'])
     )
 
     # generate random permutations without loop by generating large number of
     # random values and sorting row (meaning one permutation) wise
     permutations = np.argsort(
-        R.rand(len(ordered) // lcm_prob_denominators, lcm_prob_denominators),
+        R.rand(len(data) // lcm_prob_denominators, lcm_prob_denominators),
         axis=1
     )
     # lookup treatment name for permutations. This works because we flatten
     # row-major style, i.e. one row after another.
-    ordered['treat'] = treat_mask[permutations].flatten(order='C')
-    ordered = ordered[~ordered['fake']].drop(columns=['fake'])
+    data['treat'] = treat_mask[permutations].flatten(order='C')
+    data = data[~data['fake']].drop(columns=['fake'])
 
-    data.loc[:, 'treat'] = ordered['treat']
+    # re-assign type - as it might have changed with the addition of fake data
+    data[idx_col] = data[idx_col].astype(idx_col_type)
+    
     data['treat'] = data['treat'].astype(np.int64)
 
     assert data['treat'].isnull().sum() == 0

--- a/stochatreat/stochatreat.py
+++ b/stochatreat/stochatreat.py
@@ -241,13 +241,13 @@ def stochatreat(data: pd.DataFrame,
     )
     # lookup treatment name for permutations. This works because we flatten
     # row-major style, i.e. one row after another.
-    data['treat'] = treat_mask[permutations].flatten(order='C')
+    data.loc[:, 'treat'] = treat_mask[permutations].flatten(order='C')
     data = data[~data['fake']].drop(columns=['fake'])
 
     # re-assign type - as it might have changed with the addition of fake data
-    data[idx_col] = data[idx_col].astype(idx_col_type)
+    data.loc[:, idx_col] = data[idx_col].astype(idx_col_type)
     
-    data['treat'] = data['treat'].astype(np.int64)
+    data.loc[:, 'treat'] = data['treat'].astype(np.int64)
 
     assert data['treat'].isnull().sum() == 0
     


### PR DESCRIPTION
Avoid creation of the `ordered` object and unnecessary copy and assignments and instead work with `data` directly 

Less memory usage, slight speed-up